### PR TITLE
replaced np.NaN with np.nan

### DIFF
--- a/17-supervised-learning-with-scikit-learn/04-preprocessing-pipelines/04-dropped-missing-data.py
+++ b/17-supervised-learning-with-scikit-learn/04-preprocessing-pipelines/04-dropped-missing-data.py
@@ -16,7 +16,7 @@ Drop the rows with missing values from df using .dropna().
 Hit 'Submit Answer' to see how many rows were lost by dropping the missing values.
 '''
 # Convert '?' to NaN
-df[df == '?'] = np.NaN
+df[df == '?'] = np.nan
 
 # Print the number of NaNs
 print(df.isnull().sum())


### PR DESCRIPTION
NumPy library uses nan, rather than NaN.